### PR TITLE
Securely pre-create log file, and honor $TMPDIR

### DIFF
--- a/bin/.compile.sh
+++ b/bin/.compile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Compile redundans dependencies
 
-log="/tmp/compiling.log"
+log=`mktemp -t redundans.compiling.XXXXXXXXX.log`
 if [ ! -z $1 ]; then log=$1; fi
 
 echo `date` "Updating submodules..."


### PR DESCRIPTION
This addresses issue #65 by using mktemp(1) to pre-create the compilation log before writing to it, preventing symlink attacks. It also specifies the `-t` argument so that mktemp will honor `$TMPDIR`.

mktemp is [widely implemented](https://stackoverflow.com/questions/2792675/how-portable-is-mktemp1), so this should not introduce portability issues. 